### PR TITLE
Improve runtime performance and clang++ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 project(kangaru-example)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 add_executable(kangaru-example example/kangaru-example.cpp)
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
 install(TARGETS kangaru-example RUNTIME DESTINATION bin)

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -68,7 +68,8 @@ int E::getN() const
 	return 66;
 }
 
-struct MyContainer : Container {
+class MyContainer : public Container {
+public:
 	void init() override;
 };
 

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
-
-#include "../include/kangaru.hpp"
+#include "kangaru.hpp"
 
 using namespace std;
 using namespace kgr;

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -133,7 +133,7 @@ public:
 		auto it = _services.find(typeid(T).name());
 		
 		if (it != _services.end()) {
-			auto holder = dynamic_cast<detail::InstanceHolder<T>*>(it->second.get());
+			auto holder = static_cast<detail::InstanceHolder<T>*>(it->second.get());
 			
 			if (holder) {
 				return holder->getInstance();
@@ -162,7 +162,7 @@ private:
 			
 			return service;
 		} else {
-			auto holder = dynamic_cast<detail::InstanceHolder<T>*>(it->second.get());
+			auto holder = static_cast<detail::InstanceHolder<T>*>(it->second.get());
 			
 			if (holder) {
 				return holder->getInstance();
@@ -191,7 +191,7 @@ private:
 		auto it = _callbacks.find(typeid(T).name());
 		
 		if (it != _callbacks.end()) {
-			auto holder = dynamic_cast<detail::CallbackHolder<T, tuple_element<S, Tuple>...>*>(it->second.get());
+			auto holder = static_cast<detail::CallbackHolder<T, tuple_element<S, Tuple>...>*>(it->second.get());
 			if (holder) {
 				return holder->getCallback()(std::get<S>(dependencies)...);
 			}

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -51,7 +51,7 @@ struct Holder {
 
 template<typename T>
 struct InstanceHolder : Holder {
-	explicit InstanceHolder(std::shared_ptr<T> instance) : _instance{instance} {}
+	explicit InstanceHolder(std::shared_ptr<T> instance) : _instance{std::move(instance)} {}
 	
 	std::shared_ptr<T> getInstance() const {
 		return _instance;
@@ -65,7 +65,7 @@ template<typename T, typename... Args>
 struct CallbackHolder : Holder {
 	using callback_t = std::function<std::shared_ptr<T>(Args...)>;
 
-	explicit CallbackHolder(callback_t callback) : _callback{callback} {}
+	explicit CallbackHolder(callback_t callback) : _callback{std::move(callback)} {}
 	
 	callback_t getCallback() const {
 		return _callback;
@@ -102,8 +102,8 @@ public:
 	template<typename T>
 	void instance(std::shared_ptr<T> service) {
 		static_assert(is_service_single<T>::value, "instance only accept Single Service instance.");
-		
-		call_save_instance(service, tuple_seq<parent_types<T>>());
+
+		call_save_instance(std::move(service), tuple_seq<parent_types<T>>{});
 	}
 	
 	template<typename T>
@@ -178,7 +178,7 @@ private:
 	
 	template<typename T, int ...S>
 	void call_save_instance(std::shared_ptr<T> service, detail::seq<S...>) {
-		save_instance<T, parent_element<S, T>...>(service);
+		save_instance<T, parent_element<S, T>...>(std::move(service));
 	}
 	
 	template<typename Tuple, int ...S>
@@ -219,7 +219,7 @@ private:
 	template<typename T, typename ...Others>
 	detail::enable_if_t<(sizeof...(Others) > 0), void> save_instance(std::shared_ptr<T> service) {
 		save_instance<T>(service);
-		save_instance<Others...>(service);
+		save_instance<Others...>(std::move(service));
 	}
 	
 	template<typename T>
@@ -247,3 +247,4 @@ std::shared_ptr<T> make_container(Args&& ...args) {
 }
 
 }  // namespace kgr
+

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -97,7 +97,7 @@ private:
 	template<int S, typename T> using parent_element = typename std::tuple_element<S, parent_types<T>>::type;
 	template<int S, typename Tuple> using tuple_element = typename std::tuple_element<S, Tuple>::type;
 	using holder_ptr = std::unique_ptr<detail::Holder>;
-
+	using holder_cont = std::unordered_map<std::string, holder_ptr>;
 public:
 	template<typename T>
 	void instance(std::shared_ptr<T> service) {
@@ -232,8 +232,8 @@ private:
 		_callbacks[typeid(T).name()] = detail::make_unique<detail::CallbackHolder<T, std::shared_ptr<tuple_element<S, Tuple>>...>>(callback);
 	}
 	
-	std::unordered_map<std::string, holder_ptr> _callbacks;
-	std::unordered_map<std::string, holder_ptr> _services;
+	holder_cont _callbacks;
+	holder_cont _services;
 };
 
 template<typename T = Container, typename ...Args>

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -56,7 +56,7 @@ public:
 };
 
 template<typename T>
-class InstanceHolder : public Holder {
+class InstanceHolder final : public Holder {
 public:
 	explicit InstanceHolder(std::shared_ptr<T> instance) : _instance{std::move(instance)} {}
 	
@@ -69,7 +69,7 @@ private:
 };
 
 template<typename T, typename... Args>
-class CallbackHolder : public Holder {
+class CallbackHolder final : public Holder {
 public:
 	using callback_t = std::function<std::shared_ptr<T>(Args...)>;
 


### PR DESCRIPTION
What's new:
* Add Holder container alias.
* Less RTTI (better runtime performance):
 * don't use typeid();
 * use static_cast instead of dynamic_cast.
* Move shared pointers instead of copy (should be faster).
* Better clang++ compatibility (tested with clang++-3.5).