### PR TITLE
Develop merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 Kangaru
 =======
-Kangaru is a simple dependency injection container library for C++11. It manages multiple level of dependency. The name Kangaru came from the feature of injecting itself as a dependency into a service.
+
+Kangaru is a simple dependency injection container library for C++11.
+It manages multiple level of dependency. The name Kangaru came from the
+feature of injecting itself as a dependency into a service.
 
 Getting Started
 ---------------
-Getting started with Kangaru is easy. First of all, you need to include the library:
+
+Getting started with Kangaru is easy. First of all, you need to include the
+library:
 
     #include <kangaru.hpp>
 
-Take note that you will need either to add the header to your include paths or to add it to your project.
+Take note that you will need either to add the header to your include paths or
+to add it to your project.
+
 Everything is declared in the namespace `kgr`
 
 Documentation and tutorial is in the wiki!
 
 Features
 --------
+
  * Recursive dependency resolution
  * Does not need to modify existing classes
- * Instances shared accross every services (Single Services)
+ * Instances shared across every services (Single Services)
  * Providing your own instances
  * Providing callback to construct your services
  * Self-injection
@@ -27,7 +35,10 @@ Features
 
 What's next?
 ------------
-There is some feature I would like to see become real. Here's a list of those, feel free to contribute!
- * Testing with mutliple / virtual inheritance
+
+There is some feature I would like to see become real. Here's a list of those,
+feel free to contribute!
+
+ * Testing with multiple / virtual inheritance
  * Unit tests
  * CMake

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -59,7 +59,7 @@ struct E : C {
 	// E needs MyContainer, A and B
 	// We needs A and B because C needs them
 	E(shared_ptr<MyContainer> cont_ptr, shared_ptr<A> a_ptr, shared_ptr<B> b_ptr) :
-		C {std::move(a_ptr), std::move(b_ptr)}, container{std::move(cont_ptr)} {}
+		C {std::move(a_ptr), std::move(b_ptr)}, container{cont_ptr} {}
 
 	int getN() const override;
 

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -10,7 +10,8 @@ struct MyContainer;
 //      Service Classes      //
 ///////////////////////////////
 struct A {
-	A(int n = 0) : n{n} {};
+	A() = default;
+	A(int val) : n{val} {}
 
 	// A needs nothing
 	int n = 0;
@@ -18,7 +19,7 @@ struct A {
 
 struct B {
 	// B needs A
-	B(shared_ptr<A> a) : a{a} {}
+	B(shared_ptr<A> a_ptr) : a{std::move(a_ptr)} {}
 
 	shared_ptr<A> a;
 };
@@ -29,7 +30,7 @@ struct AC {
 
 struct C : AC {
 	// C needs A and B
-	C(shared_ptr<A> a, shared_ptr<B> b) : a{a}, b{b} {}
+	C(shared_ptr<A> a_ptr, shared_ptr<B> b_ptr) : a{std::move(a_ptr)}, b{std::move(b_ptr)} {}
 
 	int getN() const override;
 
@@ -45,7 +46,7 @@ int C::getN() const
 
 struct D {
 	// D needs B and AC
-	D(shared_ptr<B> b, shared_ptr<AC> c) : b{b}, c{c} {}
+	D(shared_ptr<B> b_ptr, shared_ptr<AC> c_ptr) : b{std::move(b_ptr)}, c{std::move(c_ptr)} {}
 
 	shared_ptr<B> b;
 	shared_ptr<AC> c;
@@ -54,8 +55,8 @@ struct D {
 struct E : C {
 	// E needs MyContainer, A and B
 	// We needs A and B because C needs them
-	E(shared_ptr<MyContainer> container, shared_ptr<A> a, shared_ptr<B> b) :
-		C {a, b}, container{container} {}
+	E(shared_ptr<MyContainer> cont_ptr, shared_ptr<A> a_ptr, shared_ptr<B> b_ptr) :
+		C {std::move(a_ptr), std::move(b_ptr)}, container{std::move(cont_ptr)} {}
 
 	int getN() const override;
 

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -117,8 +117,8 @@ int main()
 	auto container = make_container<MyContainer>();
 
 	container->callback<D>([](std::shared_ptr<B> b, std::shared_ptr<AC> ac) {
-		cout << "a D is built" << endl;
-		return make_shared<D>(b, ac);
+		cout << "a D is built\n";
+		return make_shared<D>(std::move(b), std::move(ac));
 	});
 
 	// let's get some services
@@ -130,7 +130,7 @@ int main()
 	auto d2 = container->service<D>();
 	auto e = container->service<E>();
 
-	cout << "a default value: " << a->n << endl;
+	cout << "a default value: " << a->n;
 
 	a->n = 9;
 	b->a->n = 8;
@@ -138,13 +138,14 @@ int main()
 	// Since A is single, we will see the value 5 across all classes
 	e->a->n = 5;
 
-	cout << "is same container: " << (e->container.lock() == container ? "true" : "false") << endl;
-	cout << "is same D: " << (d1 == d2 ? "true" : "false") << endl;
-	cout << "is same A: " << ((a == b->a) && (a == e->a) ? "true" : "false") << endl;
-	cout << "a: " << a->n << endl;
-	cout << "b: " << b->a->n << endl;
-	cout << "c (it's a E): " << c->getN() << endl;
-	cout << "ac (it's a C): " << ac->getN() << endl;
-	cout << "d1 n: " << d1->b->a->n << endl;
-	cout << "d2 c getN(): " << d2->c->getN() << endl;
+	cout << boolalpha;
+	cout << "\nis same container: " << (e->container.lock() == container);
+	cout << "\nis same D: " << (d1 == d2);
+	cout << "\nis same A: " << ((a == b->a) && (a == e->a));
+	cout << "\na: " << a->n;
+	cout << "\nb: " << b->a->n;
+	cout << "\nc (it's a E): " << c->getN();
+	cout << "\nac (it's a C): " << ac->getN();
+	cout << "\nd1 n: " << d1->b->a->n;
+	cout << "\nd2 c getN(): " << d2->c->getN() << '\n';
 }

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -108,7 +108,7 @@ template<> struct Service<E> : Dependency<MyContainer, A, B>, Overrides<C> {};
 ///////////////////////////////
 //        Usage Example      //
 ///////////////////////////////
-int main(int argc, char** argv)
+int main()
 {
 	auto container = make_container<MyContainer>();
 
@@ -143,6 +143,4 @@ int main(int argc, char** argv)
 	cout << "ac (it's a C): " << ac->getN() << endl;
 	cout << "d1 n: " << d1->b->a->n << endl;
 	cout << "d2 c getN(): " << d2->c->getN() << endl;
-
-	return 0;
 }

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -73,7 +73,8 @@ int E::getN() const
 }
 
 struct MyContainer : Container {
-	void init() override;
+protected:
+	virtual void init() override;
 };
 
 void MyContainer::init()

--- a/example/kangaru-example.cpp
+++ b/example/kangaru-example.cpp
@@ -11,7 +11,7 @@ struct MyContainer;
 ///////////////////////////////
 struct A {
 	A() = default;
-	A(int val) : n{val} {}
+	explicit A(int val) : n{val} {}
 
 	// A needs nothing
 	int n = 0;
@@ -25,8 +25,11 @@ struct B {
 };
 
 struct AC {
+	virtual ~AC();
 	virtual int getN() const = 0;
 };
+
+AC::~AC() = default;
 
 struct C : AC {
 	// C needs A and B

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -177,12 +177,12 @@ private:
 		} 
 		return static_cast<detail::InstanceHolder<T>*>(it->second.get())->getInstance();
 	}
-	
+
 	template<typename T, disable_if<is_service_single<T>> = null>
 	std::shared_ptr<T> get_service() {
 		return make_service<T>();
 	}
-	
+
 	template<typename T, int ...S>
 	void call_save_instance(std::shared_ptr<T> service, detail::seq<S...>) {
 		save_instance<T, parent_element<S, T>...>(std::move(service));

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -140,7 +140,7 @@ public:
 		auto it = _services.find(&detail::type_id<T>);
 		
 		if (it != _services.end()) {
-			return static_cast<detail::InstanceHolder<T>*>(it->second.get())->getInstance();
+			return static_cast<detail::InstanceHolder<T>&>(*it->second).getInstance();
 		}
 		
 		return {};
@@ -190,9 +190,9 @@ private:
 	template<typename T, typename Tuple, int ...S>
 	std::shared_ptr<T> callback_make_service(detail::seq<S...>, Tuple dependencies) const {
 		auto it = _callbacks.find(&detail::type_id<T>);
-		
+
 		if (it != _callbacks.end()) {
-			return (*static_cast<detail::CallbackHolder<T, tuple_element<S, Tuple>...>*>(it->second.get()))(std::get<S>(dependencies)...);
+			return static_cast<detail::CallbackHolder<T, tuple_element<S, Tuple>...>&>(*it->second)(std::get<S>(dependencies)...);
 		}
 		
 		return {};

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -62,16 +62,25 @@ struct Holder {
 	virtual ~Holder() = default;
 };
 
-template<typename T>
 struct InstanceHolder final : Holder {
-	explicit InstanceHolder(std::shared_ptr<T> instance) : _instance{std::move(instance)} {}
-	
+	template <typename T>
+	explicit InstanceHolder(std::shared_ptr<T> instance_ptr) :
+		_instance{static_cast<void*>(
+				new std::shared_ptr<T>{
+					std::move(instance_ptr)}),
+			&deleter<T> } {}
+
+	template <typename T>
 	std::shared_ptr<T> getInstance() const {
-		return _instance;
+		return *reinterpret_cast<std::shared_ptr<T>*>(_instance.get());
 	}
-	
 private:
-	std::shared_ptr<T> _instance;
+	template <typename T>
+	static void deleter(void *ptr) {
+		delete reinterpret_cast<std::shared_ptr<T>*>(ptr);
+	}
+
+	std::unique_ptr<void, void(*)(void*)> _instance;
 };
 
 template<typename T, typename... Args>
@@ -251,7 +260,7 @@ public:
 		auto it = _services.find(&detail::type_id<T>);
 		
 		if (it != _services.end()) {
-			return static_cast<detail::InstanceHolder<T>&>(*it->second).getInstance();
+			return static_cast<detail::InstanceHolder&>(*it->second).getInstance<T>();
 		}
 		
 		return {};
@@ -287,7 +296,7 @@ private:
 			
 			return service;
 		} 
-		return static_cast<detail::InstanceHolder<T>*>(it->second.get())->getInstance();
+		return static_cast<detail::InstanceHolder*>(it->second.get())->getInstance<T>();
 	}
 	
 	template<typename T, typename ...Args, disable_if<is_service_single<T>> = null>
@@ -342,7 +351,7 @@ private:
 	
 	template<typename T>
 	void save_instance (std::shared_ptr<T> service) {
-		_services[&detail::type_id<T>] = detail::make_unique<detail::InstanceHolder<T>>(std::move(service));
+		_services[&detail::type_id<T>] = detail::make_unique<detail::InstanceHolder>(std::move(service));
 	}
 	
 	template<typename T, typename Tuple, int ...S, typename U>

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -44,7 +44,9 @@ struct seq_gen<0, S...> {
 	using type = seq<S...>;
 };
 
-struct Holder {};
+struct Holder {
+	virtual ~Holder() = default;
+};
 
 template<typename T>
 struct InstanceHolder final : Holder {
@@ -152,7 +154,7 @@ public:
 		
 		save_callback<T, dependency_types<T>>(tuple_seq<dependency_types<T>>{}, callback);
 	}
-	
+
 	virtual void init(){}
 	
 private:

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -104,7 +104,7 @@ public:
 	Container(Container &&) = default;
 	Container& operator =(const Container &) = default;
 	Container& operator =(Container &&) = default;
-	~Container() = default;
+	virtual ~Container() = default;
 
 	template<typename T>
 	void instance(std::shared_ptr<T> service) {

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -174,11 +174,8 @@ private:
 			instance(service);
 			
 			return service;
-		} else {
-			return static_cast<detail::InstanceHolder<T>*>(it->second.get())->getInstance();
-		}
-		
-		return {};
+		} 
+		return static_cast<detail::InstanceHolder<T>*>(it->second.get())->getInstance();
 	}
 	
 	template<typename T, disable_if<is_service_single<T>> = null>
@@ -211,11 +208,7 @@ private:
 	std::shared_ptr<T> make_service(detail::seq<S...> seq, Tuple dependencies) const {
 		auto service = callback_make_service<T, Tuple>(seq, dependencies);
 		
-		if (service) {
-			return service;
-		}
-		
-		return std::make_shared<T>(std::get<S>(dependencies)...);
+		return service ? service : std::make_shared<T>(std::get<S>(dependencies)...);
 	}
 
 	template <typename T>

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -30,18 +30,18 @@ namespace detail {
 
 enum class enabler {};
 
-template <bool B, typename T>
-using enable_if_t = typename std::enable_if<B, T>::type;
+template <bool b, typename T>
+using enable_if_t = typename std::enable_if<b, T>::type;
 
 template<int ...>
-struct seq { };
+struct seq {};
 
-template<int N, int ...S>
-struct seq_gen : seq_gen<N-1, N-1, S...> { };
+template<int n, int ...s>
+struct seq_gen : seq_gen<n-1, n-1, s...> {};
 
-template<int ...S>
-struct seq_gen<0, S...> {
-	using type = seq<S...>;
+template<int ...s>
+struct seq_gen<0, s...> {
+	using type = seq<s...>;
 };
 
 struct Holder {};

--- a/include/kangaru.hpp
+++ b/include/kangaru.hpp
@@ -62,27 +62,25 @@ struct Holder {
 	virtual ~Holder() = default;
 };
 
-struct InstanceHolder final {
-	InstanceHolder() : _instance{ nullptr, &deleter<void> } {}
-	template <typename T>
-	explicit InstanceHolder(std::shared_ptr<T> instance_ptr) :
-		_instance{static_cast<void*>(
-				new std::shared_ptr<T>{
-					std::move(instance_ptr)}),
-			&deleter<T> } {}
+using InstanceHolder = std::unique_ptr<void, void(*)(void*)>;
 
-	template <typename T>
-	std::shared_ptr<T> getInstance() const {
-		return *reinterpret_cast<std::shared_ptr<T>*>(_instance.get());
-	}
-private:
-	template <typename T>
-	static void deleter(void *ptr) {
-		delete reinterpret_cast<std::shared_ptr<T>*>(ptr);
-	}
+template <typename T>
+static void instance_deleter(void *ptr) noexcept(std::is_nothrow_destructible<T>::value) {
+	delete reinterpret_cast<std::shared_ptr<T>*>(ptr);
+}
 
-	std::unique_ptr<void, void(*)(void*)> _instance;
-};
+template <typename T>
+InstanceHolder make_instance_holder(std::shared_ptr<T> ptr) {
+	return InstanceHolder{static_cast<void*>(
+			new std::shared_ptr<T>{std::move(ptr)}),
+			&instance_deleter<T>
+	};
+}
+
+template <typename T>
+std::shared_ptr<T> get_instance(InstanceHolder &holder) {
+	return *reinterpret_cast<std::shared_ptr<T>*>(holder.get());
+}
 
 template<typename T, typename... Args>
 struct CallbackHolder final : Holder {
@@ -262,7 +260,7 @@ public:
 		auto it = _services.find(&detail::type_id<T>);
 		
 		if (it != _services.end()) {
-			return it->second.template getInstance<T>();
+			return detail::get_instance<T>(it->second);
 		}
 		
 		return {};
@@ -298,7 +296,7 @@ private:
 			
 			return service;
 		} 
-		return it->second.template getInstance<T>();
+		return detail::get_instance<T>(it->second);
 	}
 	
 	template<typename T, typename ...Args, disable_if<is_service_single<T>> = null>
@@ -353,7 +351,14 @@ private:
 	
 	template<typename T>
 	void save_instance (std::shared_ptr<T> service) {
-		_services[&detail::type_id<T>] = detail::InstanceHolder{std::move(service)};
+		auto instance_holder = detail::make_instance_holder(std::move(service));
+
+		auto instance = _services.find(&detail::type_id<T>);
+		if (instance != _services.end()) {
+			instance->second = std::move(instance_holder);
+		} else {
+			_services.emplace(std::make_pair(&detail::type_id<T>, std::move(instance_holder)));
+		}
 	}
 	
 	template<typename T, typename Tuple, int ...S, typename U>


### PR DESCRIPTION
* Fixed some warnings:
 * -Wshadow (shadowing variable names);
 * -Wunused (unused variables);
 * -Wnon-virtual-dtor (non virtual destructors for base classes with virtual function members).
* Fixed memory leak (Holder destructor _must be virtual_).
* Improved example.
* `init()` function moved to protected section. (See Scott Meyers' _"Effective C++"_ advices.)
* etc. (See commit messages.)