### PR TITLE
Revert "Added CI for clang 3.5"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ sudo: false
 matrix:
   include:
     - os: linux
-      env: LLVM_VERSION=3.5.2
-      addons: { apt: { packages: ["clang-3.5"], sources: ["llvm-toolchain-precise-3.5", "ubuntu-toolchain-r-test"] } }
-      
-    - os: linux
       env: LLVM_VERSION=3.6.2
       addons: { apt: { packages: ["clang-3.6"], sources: ["llvm-toolchain-precise-3.6", "ubuntu-toolchain-r-test"] } }
 


### PR DESCRIPTION
Reverts gracicot/kangaru#51

Clang 3.5 support will be dropped from the `v4.0` release. More detail here: #52 