### PR TITLE
Fix instantiation of a class containing an abstract member

### DIFF
--- a/include/kangaru/detail/injected.hpp
+++ b/include/kangaru/detail/injected.hpp
@@ -151,9 +151,10 @@ struct forwarded_inject {
 	/*
 	 * We need this conversion operator to not break API compatibility
 	 */
-	template<typename U, enable_if_t<!is_single<U>::value && std::is_convertible<T, U>::value, int> = 0>
-	operator forwarded_inject<typename std::remove_reference<U>::type>() {
-		return forwarded_inject<typename std::remove_reference<U>::type>{std::move(forward())};
+	template<typename U, enable_if_t<
+		!is_single<U>::value && (std::is_same<typename std::remove_reference<T>::type, U>::value || (std::is_rvalue_reference<U>::value && !std::is_reference<T>::value)), int> = 0>
+	operator forwarded_inject<U>() {
+		return forwarded_inject<U>{std::move(forward())};
 	}
 };
 

--- a/test/src/definition.cpp
+++ b/test/src/definition.cpp
@@ -208,7 +208,7 @@ bool constructor_called = false;
 
 struct Service {};
 struct Definition {
-	Definition(kgr::in_place_t) { constructor_called = true; }
+	explicit Definition(kgr::in_place_t) { constructor_called = true; }
 	static auto construct() -> decltype(kgr::inject()) { return kgr::inject(); }
 	Service forward() { return {}; }
 };

--- a/test/src/virtual.cpp
+++ b/test/src/virtual.cpp
@@ -371,7 +371,7 @@ TEST_CASE("A service can depend on a avbstract service", "[virtual]") {
 	struct Impl : A { void a() override {} };
 	
 	struct Use {
-		Use(A const& a_) : a{a_} {}
+		Use(A const& a_) : a(a_) {}
 		A const& a;
 	};
 	


### PR DESCRIPTION
The commit 41de4c7 introduced a bug that would essentially instantiate a class containing an abstract member. It was reported in #91.

This pull request fixes this bug by restricting the conversion operator to only convert between a compatible set of reference types, and also adds a test that check if the problematic code works again.