### PR TITLE
Allow checking for service in lazy service

### DIFF
--- a/doc/section08_operator.md
+++ b/doc/section08_operator.md
@@ -134,9 +134,15 @@ You can use it like this:
 ```c++
 // The contained 'MessageBus&' is not constructed yet.
 kgr::lazy<MessageBusService> lazy_message_bus = container.service<kgr::lazy_service<MessageBusService>>();
+ 
+// Has not yet been constructed
+std::cout << "Constructed?: " << static_cast<bool>(lazy_message_bus);
 
 // MessageBusService is constructed here, the operator* is used.
 std::cout << *lazy_message_bus;
+
+// Now has been constructed
+std::cout << "Constructed?: " << lazy_message_bus.has_value();
 
 // The same instance is reused again and returned by operator->
 lazy_message_bus->process_messages();

--- a/include/kangaru/detail/lazy_base.hpp
+++ b/include/kangaru/detail/lazy_base.hpp
@@ -42,6 +42,17 @@ public:
 	rref operator*() && {
 		return std::move(get());
 	}
+
+	operator bool() const {
+		return has_value();
+	}
+
+	bool has_value() const {
+		if (_service.has_value())
+			return true;
+		const kgr::container& c = this->container();
+		return c.contains<T>();
+	}
 	
 private:
 	optional<service_type<T>> _service;

--- a/test/src/operator.cpp
+++ b/test/src/operator.cpp
@@ -142,6 +142,8 @@ TEST_CASE("Lazy service defer service call", "[operator]") {
 	auto lazy1 = container.service<kgr::lazy_service<Definition1>>();
 	
 	CHECK(!service1_constructed);
+	CHECK(!lazy1.has_value());
+	CHECK(!lazy1);
 	CHECK(sizeof(decltype(lazy1)) == sizeof(kgr::container*) + sizeof(void*));
 	CHECK(sizeof(kgr::optional<kgr::service_type<Definition1>>) == sizeof(void*));
 	CHECK(kgr::detail::is_trivially_copy_constructible<decltype(lazy1)>::value);
@@ -154,6 +156,8 @@ TEST_CASE("Lazy service defer service call", "[operator]") {
 	auto& service1 = *lazy1;
 	
 	CHECK(service1_constructed);
+	CHECK(lazy1.has_value());
+	CHECK(lazy1);
 	REQUIRE((std::is_same<decltype(service1), Service1&>::value));
 	
 	auto lazy2 = container.service<kgr::lazy_service<Definition2>>();


### PR DESCRIPTION
Lazy services exist for only optionally used services, as such it makes sense to also distribute the global information whether the contained service is being used through them.

This is mostly a minor change that I think would still be fair to add to 4.x.

In my case there is a part of my application that isn't needed on every run, and the easiest way to distribute the information whether that part is active or not is through the already existing lazy services.