### PR TITLE
Update the minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(KANGARU_VERSION_MAJOR "4")
 set(KANGARU_VERSION_MINOR "3")


### PR DESCRIPTION
This PR addresses the issue reported in #120 by updating the project's minimum required CMake version to 3.5.