### PR TITLE
Fix autowire_service alias

### DIFF
--- a/include/kangaru/autowire.hpp
+++ b/include/kangaru/autowire.hpp
@@ -167,7 +167,7 @@ using mapped_autowire = detail::autowire_map<service, detail::decay_t, Map, max_
  * It act as a shorter alternative to service<Type, kgr::mapped_autowire<...>>
  */
 template<typename T, typename Map = map<>, std::size_t max_dependencies = detail::default_max_dependency>
-using autowire_service = single_service<T, kgr::mapped_autowire<Map, max_dependencies>>;
+using autowire_service = service<T, kgr::mapped_autowire<Map, max_dependencies>>;
 
 template<typename T, typename Map = map<>, std::size_t max_dependencies = detail::default_max_dependency>
 using autowire_single_service = single_service<T, kgr::mapped_autowire<Map, max_dependencies>>;

--- a/test/src/autowire.cpp
+++ b/test/src/autowire.cpp
@@ -96,6 +96,27 @@ namespace test_autowire_single {
 	}
 }
 
+namespace test_autowire_service {
+	int copy_count = 0;
+
+	struct service {
+		service() = default;
+		service(service const&) { ++copy_count; }
+		service(service&&) = default;
+	};
+
+	TEST_CASE("autowire_service behaves as a non-single service", "[autowire]") {
+		copy_count = 0;
+
+		kgr::container container;
+		auto instance = container.service<kgr::autowire_service<service>>();
+		(void) instance;
+
+		REQUIRE_FALSE(kgr::detail::is_single<kgr::autowire_service<service>>::value);
+		CHECK(copy_count == 0);
+	}
+}
+
 namespace test_autowire_multiple_dependency {
 	int nb_s1_constructed;
 	


### PR DESCRIPTION
`autowire_service` currently resolves to `single_service`, so `container.service` returns a reference instead of a value. Use `service` for the non-single shortcut, matching the alias documentation.

The regression test verifies that the alias is not single and that obtaining its value does not copy it.

Tests:
- `git diff --check`
- Not run: CMake and a C++ compiler are unavailable in this environment.

Fixes #126.